### PR TITLE
replace blocksperra with era's actual total number of blocks

### DIFF
--- a/appchain/benchmarking/src/mock.rs
+++ b/appchain/benchmarking/src/mock.rs
@@ -219,7 +219,7 @@ impl pallet_octopus_lpos::Config for Test {
 	type Reward = (); // rewards are minted from the void
 	type SessionsPerEra = SessionsPerEra;
 	type BondingDuration = BondingDuration;
-	type BlocksPerEra = BlocksPerEra;
+	// type BlocksPerEra = BlocksPerEra;
 	type SessionInterface = Self;
 	type AppchainInterface = OctopusAppchain;
 	type UpwardMessagesInterface = OctopusUpwardMessages;

--- a/appchain/src/mock.rs
+++ b/appchain/src/mock.rs
@@ -220,7 +220,6 @@ impl pallet_octopus_lpos::Config for Test {
 	type Reward = (); // rewards are minted from the void
 	type SessionsPerEra = SessionsPerEra;
 	type BondingDuration = BondingDuration;
-	type BlocksPerEra = BlocksPerEra;
 	type SessionInterface = Self;
 	type AppchainInterface = OctopusAppchain;
 	type UpwardMessagesInterface = OctopusUpwardMessages;

--- a/appchain/src/tests.rs
+++ b/appchain/src/tests.rs
@@ -659,6 +659,7 @@ fn test_submit_validator_sets_on_chain() {
 		OctopusAppchain::observing_mainchain(
 			2,
 			"https://rpc.testnet.near.org",
+			"https://rpc.testnet.near.org",
 			b"oct-test.testnet".to_vec(),
 			public.clone(),
 			public.into_account().encode(), // default value.
@@ -731,6 +732,7 @@ fn test_submit_notifies_on_chain() {
 		assert_ok!(OctopusAppchain::force_set_next_set_id(Origin::root(), 1));
 		OctopusAppchain::observing_mainchain(
 			2,
+			"https://rpc.testnet.near.org",
 			"https://rpc.testnet.near.org",
 			b"oct-test.testnet".to_vec(),
 			public.clone(),

--- a/lpos/src/mock.rs
+++ b/lpos/src/mock.rs
@@ -302,7 +302,6 @@ impl Config for Test {
 	type Reward = ();
 	type SessionsPerEra = SessionsPerEra;
 	type BondingDuration = BondingDuration;
-	type BlocksPerEra = BlocksPerEra;
 	type SessionInterface = Self;
 	type AppchainInterface = OctopusAppchain;
 	type UpwardMessagesInterface = OctopusUpwardMessages;


### PR DESCRIPTION
The modification in this PR is as follows:
* replace blocksperra with era's actual total number of blocks
* fix test in #70 